### PR TITLE
Masking input variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,120 @@
 [![npm package][npm-badge]][npm]
 [![npm downloads][npm-downloads-badge]][npm]
 
-Graphql Mask is a simple utility for removing everything in a query that is not defined in a schema. Use it the same way you would use the library function for `graphql-js` e.g. `graphqlMask(schema, query)` but instead of getting back results, you will get back a trimmed down query.
+Graphql Mask is a simple utility for removing everything in a query (or its variables) that is not defined in a schema. Use it by passing in an arguments object containing the schema to mask against, the query to be masked, and optionally, the variables to be masked:
+
+```
+const { maskedQuery, maskedVariables } = graphqlMask({schema, query, variables});
+```
 
 ## Usage
 
 ```bash
 $ npm install graphql-mask
-# or 
+# or
 $ yarn add graphql-mask
 ```
+
+Filtering a query:
 
 ```
 const graphqlMask = require("graphql-mask");
 // const graphqlMask = require("graphql-mask/es5"); if you need to use this in a browser
 
+const { maskedQuery } = graphqlMask({
+  schema: `
+    type Query {
+      something: String!
+      somethingElse: Int
+    }
+  `,
+  query: `
+    query ExampleQuery {
+      something
+      somethingElse
+      somethingNotInSchema
+    }
+  `}
+})
+
+console.log(maskedQuery)
+```
+
+This will print...
+
+```graphql
+query ExampleQuery {
+  something
+  somethingElse
+}
+```
+
+Since GraphQL 0.14.0 now supports the extension of `input` types, you can now use `grapqhl-mask` to filter input variables as well:
+
+```
+const { maskedQuery, maskedVariables } = graphqlMask({
+  schema: `
+    type Query {
+      something: String!
+    }
+
+    type Mutation {
+      mutateSomething(something: SomethingInput): SomethingOutput
+    }
+
+    input SomethingInput {
+      thisThing: String
+    }
+
+    type SomethingOutput {
+      thisThing: String
+    }
+  `,
+  query: `
+    mutation ExampleMutation($something: SomethingInput) {
+      mutationSomething(something: $something) {
+        thisThing
+        thatThing
+      }
+    }
+  `,
+  variables: {
+    something: {
+      thisThing: "Apple",
+      thatThing: "Orange"
+    }
+  }
+});
+
+console.log(maskedQuery)
+console.log(maskedVariables);
+```
+
+This will print...
+
+```graphql
+mutation ExampleMutation($something: SomethingInput) {
+  mutationSomething(something: $something) {
+    thisThing
+  }
+}
+```
+
+and
+
+```
+{
+  something: {
+    thisThing: "Apple",
+  }
+}
+```
+
+# Deprecated usage
+
+To support filtering of both query and input variables, the following usage has been deprecated as of v0.1.0. This method of invoking `graphql-mask` is still supported, but wil result in warning messages.
+
+```
 const result = graphqlMask(`
   type Query {
     something: String!
@@ -37,6 +137,7 @@ console.log(result)
 ```
 
 This will print...
+
 ```graphql
 query ExampleQuery {
   something
@@ -45,10 +146,7 @@ query ExampleQuery {
 ```
 
 [build-badge]: https://circleci.com/gh/brysgo/graphql-mask.svg?style=shield
-
-[build]: 
-https://circleci.com/gh/brysgo/graphql-mask
-
+[build]: https://circleci.com/gh/brysgo/graphql-mask
 [npm-badge]: https://img.shields.io/npm/v/graphql-mask.png?style=flat-square
 [npm]: https://www.npmjs.org/package/graphql-mask
-[npm-downloads-badge]:https://img.shields.io/npm/dt/graphql-mask.svg
+[npm-downloads-badge]: https://img.shields.io/npm/dt/graphql-mask.svg

--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@
 
 Graphql Mask is a simple utility for removing everything in a query (or its variables) that is not defined in a schema. Use it by passing in an arguments object containing the schema to mask against, the query to be masked, and optionally, the variables to be masked:
 
-```
-const { maskedQuery, maskedVariables } = graphqlMask({schema, query, variables});
+```javascript
+const { maskedQuery, maskedVariables } = graphqlMask({
+  schema,
+  query,
+  variables
+});
 ```
 
 ## Usage
@@ -22,7 +26,7 @@ $ yarn add graphql-mask
 
 Filtering a query:
 
-```
+```javascript
 const graphqlMask = require("graphql-mask");
 // const graphqlMask = require("graphql-mask/es5"); if you need to use this in a browser
 
@@ -56,7 +60,7 @@ query ExampleQuery {
 
 Since GraphQL 14 now supports the extension of `input` types, you can now use `grapqhl-mask` to filter input variables as well:
 
-```
+```javascript
 const { maskedQuery, maskedVariables } = graphqlMask({
   schema: `
     type Query {
@@ -91,7 +95,7 @@ const { maskedQuery, maskedVariables } = graphqlMask({
   }
 });
 
-console.log(maskedQuery)
+console.log(maskedQuery);
 console.log(maskedVariables);
 ```
 
@@ -107,7 +111,7 @@ mutation ExampleMutation($something: SomethingInput) {
 
 and
 
-```
+```javascript
 {
   something: {
     thisThing: "Apple",
@@ -119,21 +123,24 @@ and
 
 To support filtering of both query and input variables, the following usage has been deprecated as of v0.1.0. This method of invoking `graphql-mask` is still supported, but wil result in warning messages.
 
-```
-const result = graphqlMask(`
+```javascript
+const result = graphqlMask(
+  `
   type Query {
     something: String!
     somethingElse: Int
   }
-`,`
+`,
+  `
   query ExampleQuery {
     something
     somethingElse
     somethingNotInSchema
   }
-`)
+`
+);
 
-console.log(result)
+console.log(result);
 ```
 
 This will print...

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ query ExampleQuery {
 }
 ```
 
-Since GraphQL 0.14.0 now supports the extension of `input` types, you can now use `grapqhl-mask` to filter input variables as well:
+Since GraphQL 14 now supports the extension of `input` types, you can now use `grapqhl-mask` to filter input variables as well:
 
 ```
 const { maskedQuery, maskedVariables } = graphqlMask({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-mask",
-  "version": "0.0.14",
+  "version": "0.1.0",
   "description": "GraphQL Mask lets you subtract everything outside a schema from a query",
   "main": "src/index.js",
   "scripts": {

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -79,6 +79,17 @@ exports[`removing fields from query that aren't in schema 1`] = `
 "
 `;
 
+exports[`removing variable properties from multiple input types that don't exist in schema 1`] = `
+Object {
+  "address": Object {
+    "city": "Kitchener",
+  },
+  "user": Object {
+    "name": "Steve",
+  },
+}
+`;
+
 exports[`removing variable properties that don't exist in schema 1`] = `
 Object {
   "data": Object {

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -78,3 +78,11 @@ exports[`removing fields from query that aren't in schema 1`] = `
 }
 "
 `;
+
+exports[`removing variable properties that don't exist in schema 1`] = `
+Object {
+  "data": Object {
+    "baz": "Hello",
+  },
+}
+`;

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -44,6 +44,50 @@ exports[`passing a string schema instead of a parsed one 1`] = `
 "
 `;
 
+exports[`remove variable properties from multiple and nested input types that don't exist in schema 1`] = `
+Object {
+  "employer": Object {
+    "company": "Acme",
+  },
+  "user": Object {
+    "address": Object {
+      "city": "Kitchener",
+    },
+    "name": "Steve",
+  },
+}
+`;
+
+exports[`remove variable properties from multiple input types that don't exist in schema 1`] = `
+Object {
+  "address": Object {
+    "city": "Kitchener",
+  },
+  "user": Object {
+    "name": "Steve",
+  },
+}
+`;
+
+exports[`remove variable properties from nested input types that don't exist in schema 1`] = `
+Object {
+  "user": Object {
+    "address": Object {
+      "city": "Kitchener",
+    },
+    "name": "Steve",
+  },
+}
+`;
+
+exports[`remove variable properties that don't exist in schema 1`] = `
+Object {
+  "data": Object {
+    "baz": "Hello",
+  },
+}
+`;
+
 exports[`removes fragment (its usages) and inline fragments if it has no selection 1`] = `
 "query WithFragments {
   this {
@@ -79,21 +123,18 @@ exports[`removing fields from query that aren't in schema 1`] = `
 "
 `;
 
-exports[`removing variable properties from multiple input types that don't exist in schema 1`] = `
+exports[`removing variable properties and filtering query  1`] = `
 Object {
-  "address": Object {
-    "city": "Kitchener",
-  },
-  "user": Object {
-    "name": "Steve",
-  },
+  "maskedQuery": "mutation fuzzer($data: FuzzInput!) {
+  fuzz(data: $data) {
+    baz
+  }
 }
-`;
-
-exports[`removing variable properties that don't exist in schema 1`] = `
-Object {
-  "data": Object {
-    "baz": "Hello",
+",
+  "maskedVariables": Object {
+    "data": Object {
+      "baz": "Hello",
+    },
   },
 }
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -125,19 +125,23 @@ function maskVariables(astSchema, maskedQuery, variables) {
 
   var maskedVariables = {};
   var variableDefinitions = operation.variableDefinitions;
-  var varDefNode = variableDefinitions[0];
-  var varName = varDefNode.variable.name.value;
-  var varType = resolveType(typeFromAST(astSchema, varDefNode.type));
-  var varValue = variables[varName];
-  var varFields = varType.getFields();
-  // Ensure every provided field is defined.
-  for (var fieldName in varValue) {
-    if (Object.prototype.hasOwnProperty.call(varValue, fieldName)) {
-      if (!varFields[fieldName]) {
-        delete varValue[fieldName];
+  if (!variableDefinitions || variableDefinitions.length === 0) {
+    return maskedVariables;
+  }
+  variableDefinitions.forEach(function(varDefNode) {
+    var varName = varDefNode.variable.name.value;
+    var varType = resolveType(typeFromAST(astSchema, varDefNode.type));
+    var varValue = variables[varName];
+    var varFields = varType.getFields();
+    // Ensure every provided field is defined.
+    for (var fieldName in varValue) {
+      if (Object.prototype.hasOwnProperty.call(varValue, fieldName)) {
+        if (!varFields[fieldName]) {
+          delete varValue[fieldName];
+        }
       }
     }
-  }
-  maskedVariables[varName] = varValue;
+    maskedVariables[varName] = varValue;
+  });
   return maskedVariables;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,20 +7,14 @@ var graphqlLanguage = require("graphql/language"),
 var graphqlType = require("graphql/type"),
   GraphQLList = graphqlType.GraphQLList,
   GraphQLNonNull = graphqlType.GraphQLNonNull,
-  isInputObjectType = graphqlType.isInputObjectType,
-  isLeafType = graphqlType.isLeafType,
-  getNamedType = graphqlType.getNamedType;
+  isInputObjectType = graphqlType.isInputObjectType;
 
 var graphqlUtilities = require("graphql/utilities"),
-  TypeInfo = graphqlUtilities.TypeInfo,
   buildASTSchema = graphqlUtilities.buildASTSchema,
   typeFromAST = graphqlUtilities.typeFromAST;
 
 var graphqlValidation = require("graphql/validation"),
   validate = graphqlValidation.validate;
-
-var graphqlExecutionValues = require("graphql/execution/values"),
-  getVariableValues = graphqlExecutionValues.getVariableValues;
 
 var rules = require("./rules");
 
@@ -57,9 +51,6 @@ module.exports = function graphqlMask(argsOrSchema, deprecatedQuery) {
   var result = mask(schema, query, variables);
 
   if (deprecatedUsage) {
-    console.warn(
-      "Return value of only masked query has been deprecated. Please migrate to use return object containing masked query and variables."
-    );
     return result.maskedQuery;
   } else {
     return {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -424,19 +424,19 @@ test("removing variable properties that don't exist in schema", () => {
       }
     `)
   );
-  const { query, variables } = graphqlMask(
-    astSchema,
-    `
-    mutation fuzzer($data: FuzzInput!) {
-      fuzz(data: $data) 
-    }
-  `,
-    {
+  const { maskedVariables } = graphqlMask({
+    schema: astSchema,
+    query: `
+        mutation fuzzer($data: FuzzInput!) {
+          fuzz(data: $data) 
+        }
+      `,
+    variables: {
       data: {
         baz: "Hello",
         bar: "should be filtered"
       }
     }
-  );
-  expect(variables).toMatchSnapshot();
+  });
+  expect(maskedVariables).toMatchSnapshot();
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -440,3 +440,44 @@ test("removing variable properties that don't exist in schema", () => {
   });
   expect(maskedVariables).toMatchSnapshot();
 });
+
+test("removing variable properties from multiple input types that don't exist in schema", () => {
+  const astSchema = buildASTSchema(
+    parse(`
+      type Query {
+        foo: String
+      }
+
+      input UserInput {
+        name: String
+      }
+
+      input AddressInput {
+        city: String
+      }
+
+      type Mutation {
+        addUserAndAddress(user: UserInput, address: AddressInput): Boolean
+      }
+    `)
+  );
+  const { maskedVariables } = graphqlMask({
+    schema: astSchema,
+    query: `
+        mutation appMutation($user: UserInput!, $address: AddressInput!) {
+          addUserAndAddress(user: $user, address: $address) 
+        }
+      `,
+    variables: {
+      user: {
+        name: "Steve",
+        age: 33
+      },
+      address: {
+        street: "123 Main St.",
+        city: "Kitchener"
+      }
+    }
+  });
+  expect(maskedVariables).toMatchSnapshot();
+});

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -408,4 +408,35 @@ test("does not filter mutations with known input types", () => {
   expect(resultQueryString).toMatchSnapshot();
 });
 
+test("removing variable properties that don't exist in schema", () => {
+  const astSchema = buildASTSchema(
+    parse(`
+      type Query {
+        foo: String
+      }
 
+      input FuzzInput {
+        baz: String
+      }
+
+      type Mutation {
+        fuzz(data: FuzzInput): String
+      }
+    `)
+  );
+  const { query, variables } = graphqlMask(
+    astSchema,
+    `
+    mutation fuzzer($data: FuzzInput!) {
+      fuzz(data: $data) 
+    }
+  `,
+    {
+      data: {
+        baz: "Hello",
+        bar: "should be filtered"
+      }
+    }
+  );
+  expect(variables).toMatchSnapshot();
+});


### PR DESCRIPTION
Since GraphQL 14 now supports the extension of `input` types, it would be useful if `graphql-mask` had the capability to filter input variables.

*I made some changes to the interface/response type (and bumped the minor version to reflect the changes). These are non-breaking, but they do suggest that the previous usage should be deprecated*